### PR TITLE
fix(chart): Tweak container command to invoke GarnetServer using absolute path

### DIFF
--- a/charts/garnet/templates/statefulset.yaml
+++ b/charts/garnet/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["./GarnetServer"]
+          command: ["/app/GarnetServer"]
           {{- if or .Values.containers.args .Values.config.garnetConf .Values.config.existingSecret }}
           args:
           {{- range .Values.containers.args }}


### PR DESCRIPTION
The relative path seems to be troublesome for NanoServer container
for which, for some unclear reasons, executable cannot be found
leading to Kubernetes errors like:

    Error: failed to start containerd task garnet: hcs::System::CreateProcess:
    ./GarnetServer garnet: The system cannot find the file specified.: unknown

despite WORKDIR setting in
https://github.com/microsoft/garnet/blob/4a26c1280bfd9198c88d21cb7f1eba0a99715c60/Dockerfile.nanoserver#L18

All variations have been tested like`.\\GarnetServer` and with/without `.exe`
extension, and only absolute path seems to work. Tests were based on simplest
deployment using all the default values.

The absolute path also unifies the command across all the containers
specs in use i.e. entry point in Dockerfile-s and Helm charet command.
